### PR TITLE
Add rule-prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This project is a fork of the [amazon-ecs-deploy-task-definition](https://github
 
 ## Usage
 
-The action assumes you have already setup 1 or more tasks to run as a scheduled task in the ECS environment. This action will update _all_ of the tasks who cluster and task ARN (without version) match existing scheduled actions. To use this action simply add the following step to your deploy process:
+The action assumes you have already setup 1 or more tasks to run as a scheduled task in the ECS environment. This action will update _all_ of the tasks who cluster, task ARN (without version), and rule-prefix match existing scheduled actions or cloudwatch events. To use this action simply add the following step to your deploy process:
 
 ```yaml
 - name: Deploy to Amazon ECS Scheduled Tasks
@@ -29,6 +29,7 @@ The action assumes you have already setup 1 or more tasks to run as a scheduled 
   with:
     cluster: my-cluster
     task-definition: task-definition.json
+    rule-prefix: my-rule-prefix-
 ```
 
 The action can be passed a `task-definition` generated dynamically via [the `aws-actions/amazon-ecs-render-task-definition` action](https://github.com/aws-actions/amazon-ecs-render-task-definition).

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   task-definition:
     description: The path to the ECS task definition file to register
     required: true
+  rule-prefix:
+    default: ''
+    description: The CloudWatch Event name prefix to update
+    required: false
 outputs:
   task-definition-arn:
     description: The ARN of the registered ECS task definition

--- a/src/index.js
+++ b/src/index.js
@@ -158,6 +158,7 @@ async function run() {
       required: true,
     });
     const cluster = core.getInput('cluster', { required: false }) || 'default';
+    const rulePrefix = core.getInput('rule-prefix', { required: false }) || '';
 
     // Register the task definition
     core.debug('Registering the task definition');
@@ -189,9 +190,13 @@ async function run() {
     const data = await cwe.listRules().promise();
     const rules = (data && data.Rules) || [];
     await Promise.all(
-      rules.map(rule => {
-        return processCloudwatchEventRule(cwe, rule, cluster, taskDefArn);
-      })
+      rules
+        .filter(rule => {
+          return rule.Name.startsWith(rulePrefix);
+        })
+        .map(rule => {
+          return processCloudwatchEventRule(cwe, rule, cluster, taskDefArn);
+        })
     );
   } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
_Issue #, if available:_

nothing

_Description of changes:_

Hi, I added `rule-prefix` option to this action.
For more safety, we want to provide cloudwatch event name _prefix_ in order to exclude unnecessary cloudwatch event from `processCloudwatchEventRule`.
I also added tests for `rule-prefix` option.
This change has a backward compatibility because name-prefix is optional and default to empty string, so that `startsWith` always returns true with no rule-prefix specified.

What do you think about this change?


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
