### PR TITLE
Update to use node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,5 +19,5 @@ outputs:
   task-definition-arn:
     description: The ARN of the registered ECS task definition
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
Avoid Github Actions warning
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: airfordable/ecs-deploy-task-definition-to-scheduled-task@v2.0.0
```

_Issue #, if available:_

_Description of changes:_

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
