### PR TITLE
Update to use node20 and fix deprecated 'set-output' warning

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,5 +19,5 @@ outputs:
   task-definition-arn:
     description: The ARN of the registered ECS task definition
 runs:
-  using: node12
+  using: node16
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -19,5 +19,5 @@ outputs:
   task-definition-arn:
     description: The ARN of the registered ECS task definition
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ Update to use node20 and fix deprecated 'set-output' warning

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
